### PR TITLE
Changed docker image pull command from docker hub to github packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It also installs `native-image`
 ## Pull image
 
 ```bash
-$ docker pull softinstigate/graalvm-maven
+$ docker pull ghcr.io/softinstigate/graalvm-maven-docker
 ```
 
 ## Run ##
@@ -22,7 +22,7 @@ The default `ENTRYPOINT` for this image is `mvn`.
 If you want to `mvn clean install` your Java project, CD where the pom.xml is located, then:
 
 ```bash
-$ docker pull softinstigate/graalvm-maven
+$ docker pull ghcr.io/softinstigate/graalvm-maven-docker
 $ docker run -it --rm \
     -v "$PWD":/opt/app  \
     -v "$HOME"/.m2:/root/.m2 \

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ docker pull ghcr.io/softinstigate/graalvm-maven-docker
 $ docker run -it --rm \
     -v "$PWD":/opt/app  \
     -v "$HOME"/.m2:/root/.m2 \
-    softinstigate/graalvm-maven \
+    softinstigate/graalvm-maven-docker \
     clean package
 ```
 


### PR DESCRIPTION
Changed the `README.md` file to point to the github packages repository instead of the old docker hub image repository.
You maybe also want to delete the old image located at: https://hub.docker.com/r/softinstigate/graalvm-maven

If you still want to use docker hub, you could also extend the github action to also publish the image to docker hub:
https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-docker-hub-and-github-packages